### PR TITLE
display progress when matching

### DIFF
--- a/app/src/main/java/org/tosl/coronawarncompanion/MainActivity.java
+++ b/app/src/main/java/org/tosl/coronawarncompanion/MainActivity.java
@@ -439,7 +439,9 @@ public class MainActivity extends AppCompatActivity {
 
             if ((rpiList != null) && (diagnosisKeysList != null)) {
                 Matcher matcher = new Matcher(rpiList, diagnosisKeysList, app.getApplicationContext());
-                mainActivity.matches = matcher.findMatches();
+                mainActivity.matches = matcher.findMatches(
+                        progress -> runOnUiThread(
+                                () -> textView3.setText(getResources().getString(R.string.matching_not_done_yet_with_progress, progress))));
                 Log.d(TAG, "Finished matching, sending the message...");
                 app.setMatches(mainActivity.matches);
             }

--- a/app/src/main/java/org/tosl/coronawarncompanion/matcher/Matcher.java
+++ b/app/src/main/java/org/tosl/coronawarncompanion/matcher/Matcher.java
@@ -3,6 +3,8 @@ package org.tosl.coronawarncompanion.matcher;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.core.util.Consumer;
+
 import org.tosl.coronawarncompanion.CWCApplication;
 import org.tosl.coronawarncompanion.diagnosiskeys.DiagnosisKeysProtos;
 import org.tosl.coronawarncompanion.gmsreadout.ContactRecordsProtos;
@@ -52,10 +54,22 @@ public class Matcher {
         timeZoneOffsetSeconds = app.getTimeZoneOffsetSeconds();
     }
 
-    public LinkedList<MatchEntry> findMatches() {
+    public LinkedList<MatchEntry> findMatches(Consumer<Integer> progressCallback) {
         Log.d(TAG, "Started matching...");
         LinkedList<MatchEntry> matchEntries = new LinkedList<>();
+        int diagnosisKeysListLength = diagnosisKeysList.size();
+        int currentDiagnosisKey = 0;
+        int lastProgress = 0;
+        int currentProgress;
         for (DiagnosisKeysProtos.TemporaryExposureKey dk : diagnosisKeysList) {
+            currentDiagnosisKey += 1;
+            currentProgress = (int) (100f * currentDiagnosisKey / diagnosisKeysListLength);
+            if (currentProgress != lastProgress) {
+                lastProgress = currentProgress;
+                if (progressCallback != null) {
+                    progressCallback.accept(currentProgress);
+                }
+            }
             int dkIntervalNumber = dk.getRollingStartIntervalNumber();
             LinkedList<crypto.RpiWithInterval> dkRpisWithIntervals = createListOfRpisForIntervalRange(deriveRpiKey(dk.getKeyData().toByteArray()),
                     dkIntervalNumber, dk.getRollingPeriod());

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,4 +10,5 @@
     <string name="rpis_extracted">%d Begegnungen erfasst (%s-%s).</string>
     <string name="diagnosis_keys_downloaded">%d Diagnoseschlüssel heruntergeladen.</string>
     <string name="matching_not_done_yet">Abgleich wird erstellt…</string>
+    <string name="matching_not_done_yet_with_progress">Abgleich wird erstellt… %1$d%%</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="rpis_extracted">%d encounters scanned (%s-%s).</string>
     <string name="diagnosis_keys_downloaded">%d diagnosis keys downloaded."</string>
     <string name="matching_not_done_yet">Matching in progress…</string>
+    <string name="matching_not_done_yet_with_progress">Matching in progress… %1$d%%</string>
     <plurals name="number_of_matches_found">
         <item quantity="one">%d risk encounter. Tap to see details…</item>
         <item quantity="other">%d risk encounters. Tap to see details…</item>


### PR DESCRIPTION
When running in non-demo mode it may take a lot of time to do the matching on slower phones, displaying some progress may improve UX