### PR TITLE
Filter sightings that happened more than 14 days ago / Don't show transmission risk level in Canada

### DIFF
--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
@@ -142,6 +142,9 @@ public class MatchesRecyclerViewAdapter extends RecyclerView.Adapter<MatchesRecy
                     hasTransmissionRiskLevel = true;
                 }
                 // note that TRL is usually 0 - then it is not shown
+            } else if (dk.countryCode.equals("CA")) {
+                // transmission risk level is always set to 1
+                hasTransmissionRiskLevel = false;
             } else {
                 // all other countries
                 transmissionRiskLevel = dk.dk.getTransmissionRiskLevel();

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/ramblereadout/RambleDbOnDisk.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/ramblereadout/RambleDbOnDisk.java
@@ -67,8 +67,8 @@ public class RambleDbOnDisk {
                     if (rambleDb != null) {
                         Log.d(TAG, "Opened RaMBLE Database: " + downloadDir + "/" + rambleDbFileName);
 
-                        Cursor cursor = rambleDb.rawQuery("SELECT service_data, first_seen, last_seen, id "+
-                                        "FROM devices WHERE service_uuids='fd6f'", null);
+                        Cursor cursor = rambleDb.rawQuery("SELECT service_data, last_seen, id "+
+                                "FROM devices WHERE service_uuids='fd6f'", null);
 
                         rpiList = new RpiList();
 
@@ -79,12 +79,11 @@ public class RambleDbOnDisk {
                             byte[] rpiBytes = hexStringToByteArray(rpiStr);
                             String aemStr = rpiAemStr.substring(16*2);
                             byte[] aemBytes = hexStringToByteArray(aemStr);
-                            String firstSeenStr = cursor.getString(1);
-                            int firstSeenTimestamp = Integer.parseInt(firstSeenStr);
-                            String lastSeenStr = cursor.getString(2);
+                            String lastSeenStr = cursor.getString(1);
                             int lastSeenTimestamp = Integer.parseInt(lastSeenStr);
+                            int firstSeenTimestamp = lastSeenTimestamp;
                             if (getDaysFromSeconds(lastSeenTimestamp) >= minDaysSinceEpochUTC) {
-                                String idStr = cursor.getString(3);
+                                String idStr = cursor.getString(2);
                                 // Log.d(TAG, "Device seen: " + byteArrayToHexString(rpiBytes) + " " + byteArrayToHexString(aemBytes) +
                                 //        " " + firstSeenTimestamp + "-" + lastSeenTimestamp + " " + idStr);
 
@@ -96,6 +95,12 @@ public class RambleDbOnDisk {
                                 while (cursor2.moveToNext()) {
                                     String timestampStr = cursor2.getString(0);
                                     int timestamp = Integer.parseInt(timestampStr);
+                                    if (getDaysFromSeconds(timestamp) < minDaysSinceEpochUTC) {
+                                        continue;
+                                    }
+                                    if (timestamp < firstSeenTimestamp) {
+                                        firstSeenTimestamp = timestamp;
+                                    }
                                     String rssiStr = cursor2.getString(1);
                                     int rssi = Integer.parseInt(rssiStr);
                                     //Log.d(TAG, "Scan events: " + timestamp + " " + rssi);


### PR DESCRIPTION
My RamBLE recorded a bizarre case where the last seen time for the event was within the last 14 days but the first sightings of the event happened around Sept 10. The consequence was that the bar charts were really stretched out with their first half being empty (except at the very beginning for the RamBLE bar chart).

My code change explicitly filters out sightings that did not happen within the last 14 days. This makes the processing more robust in case weird stuff happens.

The transmission risk level is always set to one in Canada so there is no point in showing it.