### PR TITLE
Never show a plain map if we do not have a valid location.

### DIFF
--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
@@ -272,6 +272,10 @@ public class MatchesRecyclerViewAdapter extends RecyclerView.Adapter<MatchesRecy
             holder.mMapView.getOverlays().add(marker);
             holder.mMapView.invalidate();
         }
+        else {
+            // showing a default map without a marker would cause confusion
+            holder.mMapView.setVisibility(View.GONE);
+        }
 
         if (this.showAllScans) {
             String txPowerStr;

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchesRecyclerViewAdapter.java
@@ -268,6 +268,7 @@ public class MatchesRecyclerViewAdapter extends RecyclerView.Adapter<MatchesRecy
             marker.setPosition(point);
             marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
             marker.setTitle("Point of exposure");
+            holder.mMapView.setVisibility(View.VISIBLE);
             holder.mMapView.setExpectedCenter(point);
             holder.mMapView.getOverlays().add(marker);
             holder.mMapView.invalidate();


### PR DESCRIPTION
Never show a plain map if we do not have a valid location. This would cause confusion.