### PR TITLE
Introduce multithreading to matching. This speeds up the process significantly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/corona-warn-companion/build.gradle
+++ b/corona-warn-companion/build.gradle
@@ -107,32 +107,32 @@ repositories {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     //implementation 'io.github.pcmind:leveldb:1.2'  // versions > 0.9 conflict with minSdkVersion 23, e.g. because of java.lang.invoke.MethodHandle
     //noinspection GradleDependency
     implementation 'com.github.mh-:leveldb:1.2-android-minsdk23'  // created this to work with minSdkVersion 23
     implementation 'org.iq80.snappy:snappy:0.4'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
-    implementation "io.noties.markwon:core:4.5.0"
-    implementation "io.noties.markwon:image:4.5.0"
+    implementation "io.noties.markwon:core:4.6.0"
+    implementation "io.noties.markwon:image:4.6.0"
     implementation 'com.google.protobuf:protobuf-java:3.12.2'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
-    implementation 'com.google.android.material:material:1.2.0'
-    implementation 'androidx.navigation:navigation-fragment:2.3.0'
-    implementation 'androidx.navigation:navigation-ui:2.3.0'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.navigation:navigation-fragment:2.3.1'
+    implementation 'androidx.navigation:navigation-ui:2.3.1'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
     implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'org.osmdroid:osmdroid-android:6.1.6'
+    implementation 'org.osmdroid:osmdroid-android:6.1.6'  // Warning: check issue #84 before changing this version number
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.0'
 
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/dkdownload/DKDownloadUtils.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/dkdownload/DKDownloadUtils.java
@@ -21,6 +21,8 @@ import io.reactivex.schedulers.Schedulers;
 import okhttp3.OkHttpClient;
 
 import static org.tosl.coronawarncompanion.dkdownload.Unzip.getUnzippedBytesFromZipFileBytes;
+import static org.tosl.coronawarncompanion.tools.Utils.getENINFromDate;
+import static org.tosl.coronawarncompanion.tools.Utils.standardRollingPeriod;
 
 public class DKDownloadUtils {
 
@@ -58,7 +60,10 @@ public class DKDownloadUtils {
                 .map(dkListList -> dkListList
                         .stream()
                         .flatMap(List::stream)
-                        .collect(Collectors.toList()));
+                        .filter(dk -> dk.dk.getRollingStartIntervalNumber()
+                                >= getENINFromDate(minDate)-standardRollingPeriod) // -1 day because of the 2h window
+                        .collect(Collectors.toList())
+                );
     }
 
     public static List<DiagnosisKey>

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchEntryContent.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matchentries/MatchEntryContent.java
@@ -54,15 +54,14 @@ public class MatchEntryContent {
             return map.get(daysSinceEpoch);
         }
 
-        public void add(Matcher.MatchEntry entry, DiagnosisKey dk,
-                        Integer daysSinceEpochLocalTZ) {
-            if (!map.containsKey(daysSinceEpochLocalTZ)) {
-                map.put(daysSinceEpochLocalTZ, new DailyMatchEntries());
+        public void add(Matcher.MatchEntryAndDkAndDay matchEntryAndDkAndDay) {
+            if (!map.containsKey(matchEntryAndDkAndDay.daysSinceEpochLocalTZ)) {
+                map.put(matchEntryAndDkAndDay.daysSinceEpochLocalTZ, new DailyMatchEntries());
             }
-            DailyMatchEntries dailyMatchEntries = map.get(daysSinceEpochLocalTZ);
+            DailyMatchEntries dailyMatchEntries = map.get(matchEntryAndDkAndDay.daysSinceEpochLocalTZ);
             if (dailyMatchEntries != null) {
                 int previousMatchingDkCount = dailyMatchEntries.getDailyMatchingDkCount();
-                dailyMatchEntries.add(entry, dk);
+                dailyMatchEntries.add(matchEntryAndDkAndDay.matchEntry, matchEntryAndDkAndDay.diagnosisKey);
                 totalRpiCount++;
                 totalMatchingDkCount += (dailyMatchEntries.getDailyMatchingDkCount() - previousMatchingDkCount);
                 // Log.d(TAG, "Added entry for day: " + daysSinceEpochLocalTZ +

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matcher/Crypto.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matcher/Crypto.java
@@ -58,10 +58,12 @@ public class Crypto {
 
     public static byte[] deriveRpiKey(byte[] tek) {
         byte[] derivedKey = null;
-        try {
-            derivedKey = hkdfSha256(tek, null, "EN-RPIK".getBytes(StandardCharsets.UTF_8), 16);
-        } catch (CryptoException e) {
-            e.printStackTrace();
+        synchronized (Crypto.class) {
+            try {
+                derivedKey = hkdfSha256(tek, null, "EN-RPIK".getBytes(StandardCharsets.UTF_8), 16);
+            } catch (CryptoException e) {
+                e.printStackTrace();
+            }
         }
         return derivedKey;
     }

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matcher/Matcher.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/matcher/Matcher.java
@@ -19,18 +19,18 @@
 package org.tosl.coronawarncompanion.matcher;
 
 import android.util.Log;
-import android.util.Pair;
-
-import androidx.core.util.Consumer;
 
 import org.tosl.coronawarncompanion.CWCApplication;
 import org.tosl.coronawarncompanion.diagnosiskeys.DiagnosisKey;
 import org.tosl.coronawarncompanion.gmsreadout.ContactRecordsProtos;
 import org.tosl.coronawarncompanion.rpis.RpiList;
-import org.tosl.coronawarncompanion.matchentries.MatchEntryContent;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
 
 import static org.tosl.coronawarncompanion.CWCApplication.backgroundThreadsShouldStop;
 import static org.tosl.coronawarncompanion.matcher.Crypto.decryptAem;
@@ -41,8 +41,6 @@ import static org.tosl.coronawarncompanion.tools.Utils.getDaysFromSeconds;
 public class Matcher {
 
     private static final String TAG = "Matcher";
-
-    private final MatchEntryContent matchEntryContent;
 
     public static class MatchEntry {
         public final ContactRecordsProtos.ContactRecords contactRecords;
@@ -57,62 +55,96 @@ public class Matcher {
         }
     }
 
+    public static class MatchEntryAndDkAndDay {
+        public MatchEntry matchEntry;
+        public DiagnosisKey diagnosisKey;
+        public Integer daysSinceEpochLocalTZ;
+
+        public MatchEntryAndDkAndDay(MatchEntry matchEntry, DiagnosisKey diagnosisKey, Integer daysSinceEpochLocalTZ) {
+            this.matchEntry = matchEntry;
+            this.diagnosisKey = diagnosisKey;
+            this.daysSinceEpochLocalTZ = daysSinceEpochLocalTZ;
+        }
+    }
+
     private final RpiList rpiList;
     private final List<DiagnosisKey> diagnosisKeysList;
+    private final int threadNumber;
 
     final int timeZoneOffsetSeconds;
 
-    public Matcher(RpiList rpis, List<DiagnosisKey> diagnosisKeys,
-                   MatchEntryContent matchEntryContent) {
-        this.rpiList = rpis;
-        this.diagnosisKeysList = diagnosisKeys;
-        this.matchEntryContent = matchEntryContent;
-        timeZoneOffsetSeconds = CWCApplication.getTimeZoneOffsetSeconds();
+    public static class ProgressAndMatchEntryAndDkAndDay {
+        public int currentProgress;
+        public int threadNumber;
+        public MatchEntryAndDkAndDay matchEntryAndDkAndDay;
+
+        public ProgressAndMatchEntryAndDkAndDay(int currentProgress, int threadNumber, MatchEntryAndDkAndDay matchEntryAndDkAndDay) {
+            this.currentProgress = currentProgress;
+            this.threadNumber = threadNumber;
+            this.matchEntryAndDkAndDay = matchEntryAndDkAndDay;
+        }
     }
 
-    public void findMatches(Consumer<Pair<Integer, Integer>> progressCallback) {
-        Log.d(TAG, "Started matching...");
-        int diagnosisKeysListLength = diagnosisKeysList.size();
-        int currentDiagnosisKey = 0;
-        int lastProgress = 0;
-        int currentProgress;
-        int numMatches = 0;
-        Crypto crypto = new Crypto();
-        for (DiagnosisKey dk : diagnosisKeysList) {
-            if (backgroundThreadsShouldStop) {
-                break;
-            }
-            currentDiagnosisKey += 1;
-            currentProgress = (int) (100f * currentDiagnosisKey / diagnosisKeysListLength);
-            if (currentProgress != lastProgress) {
-                lastProgress = currentProgress;
-                if (progressCallback != null) {
-                    progressCallback.accept(new Pair<>(currentProgress, numMatches));
-                }
-            }
-            ArrayList<Crypto.RpiWithInterval> dkRpisWithIntervals =
-                    crypto.createListOfRpisForIntervalRange(deriveRpiKey(dk.dk.getKeyData().toByteArray()),
-                            dk.dk.getRollingStartIntervalNumber(), dk.dk.getRollingPeriod());
-            for (Crypto.RpiWithInterval dkRpiWithInterval : dkRpisWithIntervals) {
-                if (backgroundThreadsShouldStop) {
-                    break;
-                }
-                RpiList.RpiEntry rpiEntry =
-                        rpiList.searchForRpiOnDaySinceEpochUTCWith2HoursTolerance(dkRpiWithInterval);
-                if (rpiEntry != null) {
-                    Log.d(TAG, "Match found!");
-                    byte[] aemKey = deriveAemKey(dk.dk.getKeyData().toByteArray());
-                    byte[] zeroAem = {0x00, 0x00, 0x00, 0x00};
-                    byte[] aemXorBytes = decryptAem(aemKey, zeroAem, rpiEntry.rpiBytes.getBytes());
+    public Observable<ProgressAndMatchEntryAndDkAndDay> getMatchingObservable() {
+        return Observable.create(new ObservableOnSubscribe<ProgressAndMatchEntryAndDkAndDay>() {
+            @Override
+            public void subscribe(ObservableEmitter<ProgressAndMatchEntryAndDkAndDay> emitter) throws Exception {
+                try {
+                    Log.d(TAG, "Started matching...");
+                    int diagnosisKeysListLength = diagnosisKeysList.size();
+                    int currentDiagnosisKey = 0;
+                    int lastProgress = 0;
+                    int currentProgress;
+                    Crypto crypto = new Crypto();
+                    for (DiagnosisKey dk : diagnosisKeysList) {
+                        if (backgroundThreadsShouldStop || emitter.isDisposed()) {
+                            break;
+                        }
+                        currentDiagnosisKey += 1;
+                        currentProgress = (int) (100f * currentDiagnosisKey / diagnosisKeysListLength);
+                        if (currentProgress != lastProgress) {
+                            lastProgress = currentProgress;
+                            emitter.onNext(new ProgressAndMatchEntryAndDkAndDay(currentProgress, threadNumber, null));
+                        }
+                        ArrayList<Crypto.RpiWithInterval> dkRpisWithIntervals =
+                                    crypto.createListOfRpisForIntervalRange(deriveRpiKey(dk.dk.getKeyData().toByteArray()),
+                                            dk.dk.getRollingStartIntervalNumber(), dk.dk.getRollingPeriod());
+                        for (Crypto.RpiWithInterval dkRpiWithInterval : dkRpisWithIntervals) {
+                            if (backgroundThreadsShouldStop || emitter.isDisposed()) {
+                                break;
+                            }
+                            RpiList.RpiEntry rpiEntry =
+                                    rpiList.searchForRpiOnDaySinceEpochUTCWith2HoursTolerance(dkRpiWithInterval);
+                            if (rpiEntry != null) {
+                                Log.d(TAG, "Match found!");
+                                byte[] aemKey = deriveAemKey(dk.dk.getKeyData().toByteArray());
+                                byte[] zeroAem = {0x00, 0x00, 0x00, 0x00};
+                                byte[] aemXorBytes = decryptAem(aemKey, zeroAem, rpiEntry.rpiBytes.getBytes());
 
-                    this.matchEntryContent.matchEntries.add(new MatchEntry(rpiEntry.contactRecords,
-                            rpiEntry.startTimeStampUTC, aemXorBytes),
-                            dk,
-                            getDaysFromSeconds(rpiEntry.startTimeStampUTC + timeZoneOffsetSeconds));
-                    numMatches = this.matchEntryContent.matchEntries.getTotalMatchingDkCount();
+                                MatchEntryAndDkAndDay matchEntryAndDkAndDay =
+                                        new MatchEntryAndDkAndDay(
+                                                new MatchEntry(rpiEntry.contactRecords, rpiEntry.startTimeStampUTC, aemXorBytes),
+                                                dk,
+                                                getDaysFromSeconds(rpiEntry.startTimeStampUTC + timeZoneOffsetSeconds));
+                                if (!emitter.isDisposed()) {
+                                    emitter.onNext(new ProgressAndMatchEntryAndDkAndDay(currentProgress, threadNumber, matchEntryAndDkAndDay));
+                                }
+                            }
+                        }
+                    }
+                    Log.d(TAG, "Finished matching...");
+                    emitter.onComplete();
+                } catch (Exception e) {
+                    emitter.onError(e);
                 }
             }
-        }
-        Log.d(TAG, "Finished matching...");
+        });
+    }
+
+    public Matcher(RpiList rpis, List<DiagnosisKey> diagnosisKeys, int threadNumber) {
+        this.rpiList = rpis;
+        this.diagnosisKeysList = diagnosisKeys;
+        this.threadNumber = threadNumber;
+        timeZoneOffsetSeconds = CWCApplication.getTimeZoneOffsetSeconds();
     }
 }


### PR DESCRIPTION
Introduce multithreading to matching. This speeds up the process significantly. Closes #89.
Also, discard Diagnosis Keys that are too old already during download.
Synchronized hkdfSha256 access, to avoid OpenSSL crash.
Updated some dependencies.