### PR TITLE
Adding tracking functionality to corona warn app companion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/corona-warn-companion/build.gradle
+++ b/corona-warn-companion/build.gradle
@@ -88,6 +88,8 @@ android {
         github {
             dimension 'publication_version'
             applicationId 'org.tosl.coronawarncompanion'
+            resValue "string", "google_maps_key",
+                    (project.findProperty("GOOGLE_MAPS_API_KEY") ?: "")
             resValue "string", "app_name", "Corona-Warn-Companion"
             resValue "string", "about_name", "Corona-\\nWarn-\\nCompanion"
         }
@@ -119,6 +121,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.android.gms:play-services-maps:17.0.0'
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.navigation:navigation-fragment:2.3.1'
@@ -129,10 +132,12 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'org.osmdroid:osmdroid-android:6.1.6'  // Warning: check issue #84 before changing this version number
+    implementation 'com.google.android.gms:play-services-location:17.1.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.0'
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+
 }

--- a/corona-warn-companion/src/main/AndroidManifest.xml
+++ b/corona-warn-companion/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.tosl.coronawarncompanion">
 
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"></uses-permission>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -18,7 +23,19 @@
         android:theme="@style/AppTheme"
         android:requestLegacyExternalStorage="true"
         tools:ignore="AllowBackup">
-
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key" />
+        <service
+            android:enabled="true"
+            android:exported="true"
+            android:directBootAware="true"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:foregroundServiceType="location"
+            android:name="org.tosl.coronawarncompanion.tracking.LocationService"/>
         <activity
             android:name="org.tosl.coronawarncompanion.MainActivity"
             android:launchMode="singleTask"
@@ -55,5 +72,34 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.tosl.coronawarncompanion.MainActivity" />
         </activity>
+        <activity
+            android:name="org.tosl.coronawarncompanion.TrackingActivity"
+            android:configChanges="orientation"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.tosl.coronawarncompanion.MainActivity" />
+        </activity>
+        <receiver
+            android:name="org.tosl.coronawarncompanion.tracking.RestartBackgroundService"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="restartservice" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name="org.tosl.coronawarncompanion.tracking.BroadcastReceiverOnBootComplete"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter android:directBootAware="true">
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.REBOOT"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/MainActivity.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/MainActivity.java
@@ -133,7 +133,8 @@ public class MainActivity extends AppCompatActivity {
         inflater.inflate(R.menu.main_activity_menu, menu);
         if (CWCApplication.appMode == NORMAL_MODE) {
             menu.findItem(R.id.normalmode).setChecked(true);
-        } else if (CWCApplication.appMode == DEMO_MODE) {
+        }
+        else if (CWCApplication.appMode == DEMO_MODE) {
             menu.findItem(R.id.demomode).setChecked(true);
         } if (CWCApplication.appMode == RAMBLE_MODE) {
             menu.findItem(R.id.ramblemode).setChecked(true);
@@ -158,7 +159,12 @@ public class MainActivity extends AppCompatActivity {
         if (item.getItemId() == R.id.about) {
             startActivity(new Intent(this, AboutActivity.class));
             return true;
-        } else if (item.getItemId() == R.id.normalmode || item.getItemId() == R.id.demomode ||
+        }
+        else if (item.getItemId() == R.id.tracking){
+            startActivity(new Intent(this, TrackingActivity.class));
+            return true;
+        }
+        else if (item.getItemId() == R.id.normalmode || item.getItemId() == R.id.demomode ||
                 item.getItemId() == R.id.ramblemode || item.getItemId() == R.id.microgmode) {
             if (backgroundThreadsShouldStop) {
                 // user has to wait a little bit longer

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/TrackingActivity.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/TrackingActivity.java
@@ -1,0 +1,412 @@
+/*
+ * Corona-Warn-Companion. An app that shows COVID-19 Exposure Notifications details.
+ * Copyright (C) 2020  Michael Huebler <corona-warn-companion@tosl.org> and other contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.tosl.coronawarncompanion;
+
+import android.Manifest;
+import android.app.ActivityManager;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.graphics.Color;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.provider.BaseColumns;
+import android.provider.Settings;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.Toast;
+import android.widget.ToggleButton;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.maps.CameraUpdate;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.gms.maps.model.Polyline;
+import com.google.android.gms.maps.model.PolylineOptions;
+
+import org.tosl.coronawarncompanion.tracking.LocationService;
+import org.tosl.coronawarncompanion.tracking.TrackingDBHelper;
+import org.tosl.coronawarncompanion.tracking.TrackingData;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+
+public class TrackingActivity extends AppCompatActivity implements
+        GoogleMap.OnMarkerClickListener,
+        OnMapReadyCallback {
+    private TrackingDBHelper dbHelper;
+    private GoogleMap mMap;
+
+    public boolean isLocationEnabledOrNot(Context context) {
+        LocationManager locationManager = null;
+        locationManager =
+                (LocationManager)context.getSystemService(Context.LOCATION_SERVICE);
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || locationManager.isProviderEnabled(
+                LocationManager.NETWORK_PROVIDER);
+    }
+
+    public void showAlertLocation(Context context, String title, String message, String btnText) {
+        AlertDialog alertDialog = new AlertDialog.Builder(context).create();
+        alertDialog.setTitle(title);
+        alertDialog.setMessage(message);
+        alertDialog.setButton(Dialog.BUTTON_POSITIVE,"OK", new DialogInterface.OnClickListener(){
+            @Override
+            public void onClick(DialogInterface d, int arg1) {
+                alertDialog.dismiss();
+                context.startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+
+            };
+
+    });
+        alertDialog.show();
+}
+
+public void requestPermission(){
+    if (ContextCompat.checkSelfPermission(this,
+            Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED) {
+
+
+        ActivityCompat.requestPermissions(this,
+                new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                200);
+    }
+}
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_tracking);
+        SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(
+                "corona_warn_app_tracking", Context.MODE_PRIVATE);
+        boolean isTrackingEnabled =  sharedPref.getBoolean("TrackingEnabled", false);
+        ((ToggleButton)findViewById(R.id.toggle_button_tracking)).setChecked(isTrackingEnabled);
+        Calendar calendar = Calendar.getInstance();
+        Date currentTime = calendar.getTime();
+        calendar.add(Calendar.HOUR,-1);
+        Date currentTime2 = calendar.getTime();
+        SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy HH:mm");
+
+        ((EditText)findViewById(R.id.tracking_time)).setText(sdf.format(currentTime2)+" - "+sdf.format(currentTime));
+        SupportMapFragment mapFragment =
+                (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
+        mapFragment.getMapAsync(this);
+        dbHelper = new TrackingDBHelper(this);
+        if (!isLocationEnabledOrNot(this)) {
+            showAlertLocation(
+                    this,
+                    getResources().getString(R.string.title_enable_gps),
+                    getResources().getString(R.string.info_enable_gps),
+                    "OK"
+            );
+        }
+        requestPermission();
+        ((ToggleButton)findViewById(R.id.toggle_button_tracking)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+
+                    SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(
+                            "corona_warn_app_tracking", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+                    editor.putBoolean("TrackingEnabled", b);
+                    editor.apply();
+                    if (b) {
+                        startService(new Intent(TrackingActivity.this, LocationService.class));
+                    }
+                    else {
+                        Intent intent = new Intent("Service_Receiver");
+                        intent.putExtra("kill_service",true);
+                        sendBroadcast(intent);
+                    }
+            }
+        });
+        findViewById(R.id.getPosition).setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View view) {
+                InputMethodManager inputManager = (InputMethodManager) TrackingActivity.this.getSystemService(Context.INPUT_METHOD_SERVICE);
+                inputManager.hideSoftInputFromWindow(TrackingActivity.this.getCurrentFocus().getWindowToken(),InputMethodManager.HIDE_NOT_ALWAYS);
+                String dateString = ((EditText) findViewById(R.id.tracking_time)).getText().toString();
+                dateString = dateString.replace(" - ","-");
+                String[] dateStringArray = dateString.split("-");
+                if (dateStringArray.length == 1) {
+                    SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy HH:mm");
+                    long minDiff = -1;
+                    String resultTime = "";
+                    String resultLongitude = "";
+                    String resultLatitude = "";
+                    try {
+                        Date searchTime = sdf.parse(dateString);
+                        SQLiteDatabase db = dbHelper.getReadableDatabase();
+
+                        String[] projection = {
+                                BaseColumns._ID,
+                                TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE,
+                                TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE,
+                                TrackingData.TrackingEntry.COLUMN_NAME_TIME
+                        };
+
+                        String sortOrder =
+                                BaseColumns._ID + " DESC";
+
+                        Cursor cursor = db.query(
+                                TrackingData.TrackingEntry.TABLE_NAME,   // The table to query
+                                projection,             // The array of columns to return (pass null to get all)
+                                null,              // The columns for the WHERE clause
+                                null,          // The values for the WHERE clause
+                                null,                   // don't group the rows
+                                null,                   // don't filter by row groups
+                                sortOrder               // The sort order
+                        );
+                        while (cursor.moveToNext()) {
+                            String time = cursor.getString(
+                                    cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_TIME));
+                            String longitude = cursor.getString(
+                                    cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE));
+                            String latitude = cursor.getString(
+                                    cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE));
+                            Date entryTime = sdf.parse(time);
+                            if (minDiff == -1) {
+                                minDiff = Math.abs(entryTime.getTime() - searchTime.getTime());
+                                resultTime = time;
+                                resultLatitude = latitude;
+                                resultLongitude = longitude;
+                            } else {
+                                if (Math.abs(entryTime.getTime() - searchTime.getTime()) < minDiff) {
+                                    minDiff = Math.abs(entryTime.getTime() - searchTime.getTime());
+                                    resultTime = time;
+                                    resultLatitude = latitude;
+                                    resultLongitude = longitude;
+                                }
+                            }
+                        }
+                        mMap.clear();
+                        CameraUpdate center =
+                                CameraUpdateFactory.newLatLng(new LatLng(Double.parseDouble(resultLatitude), Double.parseDouble(resultLongitude)));
+                        CameraUpdate zoom = CameraUpdateFactory.zoomTo(15);
+
+                        mMap.moveCamera(center);
+                        mMap.animateCamera(zoom);
+                        mMap.addMarker(new MarkerOptions()
+                                .position(new LatLng(Double.parseDouble(resultLatitude), Double.parseDouble(resultLongitude)))
+                                .title(resultTime));
+                    } catch (ParseException e) {
+                        Toast.makeText(TrackingActivity.this, R.string.wrong_date_format, Toast.LENGTH_LONG).show();
+                    }
+                } else {
+                    String resultTime = "";
+                    String resultLongitude = "";
+                    String resultLatitude = "";
+                    String previousResultTime = "";
+                    String previousResultLongitude = "";
+                    String previousResultLatitude = "";
+
+                    SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy HH:mm");
+                    try {
+                        Date startTime = sdf.parse(dateStringArray[0]);
+                        Date endTime = sdf.parse(dateStringArray[1]);
+                        if (endTime.getTime() < startTime.getTime()){
+                            Toast.makeText(TrackingActivity.this, R.string.endtime_before_starttime,Toast.LENGTH_LONG).show();
+                        }
+                        else {
+                            SQLiteDatabase db = dbHelper.getReadableDatabase();
+
+                            String[] projection = {
+                                    BaseColumns._ID,
+                                    TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE,
+                                    TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE,
+                                    TrackingData.TrackingEntry.COLUMN_NAME_TIME
+                            };
+
+                            String sortOrder =
+                                    BaseColumns._ID + " DESC";
+
+                            Cursor cursor = db.query(
+                                    TrackingData.TrackingEntry.TABLE_NAME,   // The table to query
+                                    projection,             // The array of columns to return (pass null to get all)
+                                    null,              // The columns for the WHERE clause
+                                    null,          // The values for the WHERE clause
+                                    null,                   // don't group the rows
+                                    null,                   // don't filter by row groups
+                                    sortOrder               // The sort order
+                            );
+                            mMap.clear();
+
+                            while (cursor.moveToNext()) {
+                                String time = cursor.getString(
+                                        cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_TIME));
+                                String longitude = cursor.getString(
+                                        cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE));
+                                String latitude = cursor.getString(
+                                        cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE));
+                                Date entryTime = sdf.parse(time);
+                                if ((entryTime.getTime() <= endTime.getTime()) && (entryTime.getTime() >= startTime.getTime())) {
+
+                                    resultTime = time;
+                                    resultLatitude = latitude;
+                                    resultLongitude = longitude;
+
+                                    if (!previousResultTime.equals("")) {
+                                        Polyline line = mMap.addPolyline(new PolylineOptions()
+                                                .add(new LatLng(Double.parseDouble(resultLatitude), Double.parseDouble(resultLongitude)), new LatLng(Double.parseDouble(previousResultLatitude), Double.parseDouble(previousResultLongitude)))
+                                                .width(5)
+                                                .color(Color.RED));
+
+                                    }
+
+                                    previousResultTime = time;
+                                    previousResultLatitude = latitude;
+                                    previousResultLongitude = longitude;
+                                }
+                            }
+                            if (!resultTime.equals("")) {
+                                CameraUpdate center =
+                                        CameraUpdateFactory.newLatLng(new LatLng(Double.parseDouble(resultLatitude), Double.parseDouble(resultLongitude)));
+                                CameraUpdate zoom = CameraUpdateFactory.zoomTo(15);
+
+                                mMap.moveCamera(center);
+                                mMap.animateCamera(zoom);
+                            }
+
+                        }
+                } catch (ParseException e) {
+                    Toast.makeText(TrackingActivity.this, R.string.wrong_date_format, Toast.LENGTH_LONG).show();
+                }
+                }
+            }
+        });
+        findViewById(R.id.showTrackingData).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                AlertDialog.Builder builder = new AlertDialog.Builder(TrackingActivity.this);
+                builder.setTitle(R.string.trackingdata);
+                SQLiteDatabase db = dbHelper.getReadableDatabase();
+
+                String[] projection = {
+                        BaseColumns._ID,
+                        TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE,
+                        TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE,
+                        TrackingData.TrackingEntry.COLUMN_NAME_TIME
+                };
+
+
+
+// How you want the results sorted in the resulting Cursor
+                String sortOrder =
+                        BaseColumns._ID + " DESC";
+
+                Cursor cursor = db.query(
+                        TrackingData.TrackingEntry.TABLE_NAME,   // The table to query
+                        projection,             // The array of columns to return (pass null to get all)
+                        null,              // The columns for the WHERE clause
+                        null,          // The values for the WHERE clause
+                        null,                   // don't group the rows
+                        null,                   // don't filter by row groups
+                        sortOrder               // The sort order
+                );
+                List<String> entries = new ArrayList<String>();
+                while(cursor.moveToNext()) {
+                    String time = cursor.getString(
+                            cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_TIME));
+                    SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
+                    long diffMinutes = 0;
+                    try {
+                        Date entryTime = sdf.parse(time);
+                        Date currentTime = Calendar.getInstance().getTime();
+                        long diffSeconds = (currentTime.getTime()-entryTime.getTime())/1000;
+                        diffMinutes = diffSeconds / 60;
+
+                    } catch (ParseException e) {
+                        e.printStackTrace();
+                    }
+
+                    String entry = cursor.getString(
+                            cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE))+
+                            ":"+cursor.getString(
+                            cursor.getColumnIndexOrThrow(TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE))+
+                            ": "+ getResources().getString(R.string.before)+" "+diffMinutes+" "+ getResources().getString(R.string.minutes);
+                    entries.add(entry);
+                }
+
+                cursor.close();
+
+                String[] items = entries.toArray(new String[0]);
+
+                builder.setItems(items, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                    }
+                    });
+                builder.show();
+            }
+        });
+        // Action Bar:
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.title_activity_tracking);
+        }
+
+    }
+    public void startLocationService(){
+
+    }
+
+    @Override
+    public boolean onMarkerClick(Marker marker) {
+        return false;
+    }
+
+    private boolean isMyServiceRunning(Class<?> serviceClass) {
+        ActivityManager manager = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
+        for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+            if (serviceClass.getName().equals(service.service.getClassName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+    }
+
+}

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/BroadcastReceiverOnBootComplete.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/BroadcastReceiverOnBootComplete.java
@@ -1,0 +1,32 @@
+package org.tosl.coronawarncompanion.tracking;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+public class BroadcastReceiverOnBootComplete extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent.getAction().equalsIgnoreCase(Intent.ACTION_BOOT_COMPLETED)) {
+            SharedPreferences sharedPref = context.getSharedPreferences(
+                    "corona_warn_app_tracking", Context.MODE_PRIVATE);
+            boolean isTrackingEnabled =  sharedPref.getBoolean("TrackingEnabled", false);
+            if (isTrackingEnabled) {
+                Log.d("Tracking enabled","true");
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(new Intent(context, LocationService.class));
+                } else {
+                    context.startService(new Intent(context, LocationService.class));
+                }
+            }
+            else {
+                Log.d("Tracking enabled","false");
+
+            }
+        }
+    }
+}

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/LocationService.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/LocationService.java
@@ -1,0 +1,209 @@
+package org.tosl.coronawarncompanion.tracking;
+
+import android.Manifest;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.database.sqlite.SQLiteDatabase;
+import android.graphics.Color;
+import android.location.Location;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class LocationService extends Service {
+    private int counter = 0;
+    private double latitude = 0.0;
+    private double longitude = 0.0;
+    private Timer timer = null;
+    private TimerTask timerTask = null;
+    TrackingDBHelper dbHelper;
+    boolean killService = false;
+    BroadcastReceiver service_broadcast_receiver=new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent arg1) {
+            killService = true;
+            LocationService.this.stopSelf();
+        }
+    };
+
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        dbHelper = new TrackingDBHelper(this);
+        registerReceiver(service_broadcast_receiver, new IntentFilter("Service_Receiver"));
+        Log.i("Location Service","started service");
+        Toast.makeText(this,"Started tracking",Toast.LENGTH_LONG).show();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            createNotificationChannel();
+        } else {
+            String NOTIFICATION_CHANNEL_ID = "org.tosl.coronawarncompanion";
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
+            Notification notification = notificationBuilder.setOngoing(true)
+                    .setContentTitle("App is running count::" + counter)
+                    .setPriority(NotificationManager.IMPORTANCE_MIN)
+                    .setCategory(Notification.CATEGORY_SERVICE)
+                    .build();
+            startForeground(
+                    1,
+                    notification
+            );
+        }
+        requestLocationUpdates();
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    public void createNotificationChannel() {
+        String NOTIFICATION_CHANNEL_ID = "org.tosl.coronawarncompanion";
+        String channelName = "Location Background Service";
+        NotificationChannel chan = new NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                channelName,
+                NotificationManager.IMPORTANCE_NONE
+        );
+        chan.setLightColor(Color.BLUE);
+        chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
+        Notification notification = notificationBuilder.setOngoing(true)
+                .setContentTitle("App is running count::" + counter)
+                .setPriority(NotificationManager.IMPORTANCE_MIN)
+                .setCategory(Notification.CATEGORY_SERVICE)
+                .build();
+        NotificationManager manager = (NotificationManager)
+                (getSystemService(Context.NOTIFICATION_SERVICE));
+        manager.createNotificationChannel(chan);
+        startForeground(200, notification);
+    }
+
+    public void requestLocationUpdates() {
+        LocationRequest request = new LocationRequest();
+        request.setInterval(60000);
+        request.setFastestInterval(60000);
+        request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        FusedLocationProviderClient client  =
+                LocationServices.getFusedLocationProviderClient(this);
+
+        int permission = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+        );
+
+
+        LocationCallback locationCallback = new LocationCallback() {
+
+
+            @Override
+            public void onLocationResult(LocationResult locationResult) {
+                Location location = locationResult.getLastLocation();
+                if (location != null) {
+                    counter++;
+                    double latitude = location.getLatitude();
+                    double longitude = location.getLongitude();
+                    Log.i("Location Service", "long:"+longitude+":lat:"+latitude+":"+counter);
+                    insertNewLocation(longitude,latitude);
+                }
+            }
+        };
+        if (permission == PackageManager.PERMISSION_GRANTED) { // Request location updates and when an update is
+            // received, store the location in Firebase
+            client.requestLocationUpdates(request,locationCallback, null);
+        }
+    }
+
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        super.onStartCommand(intent, flags, startId);
+        startTimer();
+        return START_STICKY;
+    }
+
+    public void stoptimertask() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+    }
+
+    public void insertNewLocation(double longitude, double latitude){
+        SQLiteDatabase db = dbHelper.getWritableDatabase();
+
+        ContentValues values = new ContentValues();
+        String time = java.text.DateFormat.getDateTimeInstance().format(new Date());
+        values.put(TrackingData.TrackingEntry.COLUMN_NAME_LONGITUDE, ""+longitude);
+        values.put(TrackingData.TrackingEntry.COLUMN_NAME_LATITUDE, ""+latitude);
+        values.put(TrackingData.TrackingEntry.COLUMN_NAME_TIME, ""+time);
+
+        long newRowId = db.insert(TrackingData.TrackingEntry.TABLE_NAME, null, values);
+        Log.i("Location Service","inserted new row:"+newRowId);
+    }
+
+    public void startTimer() {
+        Timer timer = new Timer();
+        TimerTask timerTask = new TimerTask() {
+            @Override
+            public void run() {
+                int count = counter++;
+                if (latitude != 0.0 && longitude != 0.0) {
+                    Log.i(
+                            "Location::",
+                            latitude + ":::" + longitude + "Count" +
+                                    count
+                    );
+                }
+            }
+        };
+        timer.schedule(
+                timerTask,
+                0,
+                1000
+        );//1 * 60 * 1000 1 minute
+    }
+
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (!killService) {
+            stoptimertask();
+            Intent broadcastIntent = new Intent();
+            broadcastIntent.setAction("restartservice");
+            broadcastIntent.setClass(this, RestartBackgroundService.class);
+            this.sendBroadcast(broadcastIntent);
+        }
+        else {
+            unregisterReceiver(service_broadcast_receiver);
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/RestartBackgroundService.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/RestartBackgroundService.java
@@ -1,0 +1,22 @@
+package org.tosl.coronawarncompanion.tracking;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.widget.Toast;
+
+public class RestartBackgroundService extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Toast.makeText(context, "Tracking service restarted", Toast.LENGTH_SHORT).show();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(new Intent(context, LocationService.class));
+        } else {
+            context.startService(new Intent(context, LocationService.class));
+        }
+    }
+
+
+}

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/TrackingDBHelper.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/TrackingDBHelper.java
@@ -1,0 +1,25 @@
+package org.tosl.coronawarncompanion.tracking;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class TrackingDBHelper extends SQLiteOpenHelper {
+        public static final int DATABASE_VERSION = 1;
+        public static final String DATABASE_NAME = "Tracking.db";
+
+        public TrackingDBHelper(Context context) {
+            super(context, DATABASE_NAME, null, DATABASE_VERSION);
+        }
+        public void onCreate(SQLiteDatabase db) {
+            db.execSQL(TrackingData.SQL_CREATE_ENTRIES);
+        }
+        public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            db.execSQL(TrackingData.SQL_DELETE_ENTRIES);
+            onCreate(db);
+        }
+        public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            onUpgrade(db, oldVersion, newVersion);
+        }
+
+}

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/TrackingData.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/tracking/TrackingData.java
@@ -1,0 +1,23 @@
+package org.tosl.coronawarncompanion.tracking;
+
+import android.provider.BaseColumns;
+
+public class TrackingData {
+    public static final String SQL_CREATE_ENTRIES =
+            "CREATE TABLE " + TrackingEntry.TABLE_NAME + " (" +
+                    TrackingEntry._ID + " INTEGER PRIMARY KEY," +
+                    TrackingEntry.COLUMN_NAME_TIME + " TEXT," +
+                    TrackingEntry.COLUMN_NAME_LONGITUDE + " TEXT," +
+                    TrackingEntry.COLUMN_NAME_LATITUDE + " TEXT)";
+
+    public static final String SQL_DELETE_ENTRIES =
+            "DROP TABLE IF EXISTS " + TrackingEntry.TABLE_NAME;
+
+    public static class TrackingEntry implements BaseColumns {
+            public static final String TABLE_NAME = "tracking_entry";
+            public static final String COLUMN_NAME_LONGITUDE = "longitude";
+            public static final String COLUMN_NAME_LATITUDE = "latitude";
+            public static final String COLUMN_NAME_TIME = "time";
+
+    }
+}

--- a/corona-warn-companion/src/main/res/layout/activity_tracking.xml
+++ b/corona-warn-companion/src/main/res/layout/activity_tracking.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TrackingActivity">
+    <TextView
+        android:id="@+id/headingTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:fontFamily="sans-serif-condensed-medium"
+        android:text="Tracking"
+        android:textSize="24sp" />
+    <TextView
+        android:id="@+id/toggle_button_tracking_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_below="@id/headingTextView"
+
+        android:fontFamily="sans-serif-condensed-medium"
+        android:text="Tracking aktivieren"
+        android:textSize="18sp" />
+
+<ToggleButton
+    android:id="@+id/toggle_button_tracking"
+    android:layout_below="@id/headingTextView"
+    android:layout_toRightOf="@id/toggle_button_tracking_label"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"/>
+    <Button
+        android:id="@+id/showTrackingData"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Trackingdaten abrufen"
+        android:layout_below="@id/toggle_button_tracking"/>
+    <TextView
+        android:id="@+id/tracking_time_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Zeitpunkt:"
+        android:layout_below="@id/showTrackingData"/>
+    <EditText
+        android:layout_below="@id/showTrackingData"
+        android:id="@+id/tracking_time"
+        android:layout_toRightOf="@id/tracking_time_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+    android:hint="Example: 14.11.2020 14:30"/>
+    <Button
+        android:id="@+id/getPosition"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Position ermitteln"
+        android:layout_below="@id/tracking_time"/>
+    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_below="@id/getPosition"
+        android:id="@+id/map"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+        <!-- tools:context="com.example.mapwithmarker.MapsMarkerActivity" />-->
+
+
+
+</RelativeLayout>

--- a/corona-warn-companion/src/main/res/menu/main_activity_menu.xml
+++ b/corona-warn-companion/src/main/res/menu/main_activity_menu.xml
@@ -2,6 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/about"
         android:title="@string/menu_entry_about" />
+    <item android:id="@+id/tracking"
+        android:title="@string/menu_entry_tracking" />
     <group android:id="@+id/mode_group"
         android:checkableBehavior="single">
         <item android:id="@+id/normalmode"

--- a/corona-warn-companion/src/main/res/values-de/strings.xml
+++ b/corona-warn-companion/src/main/res/values-de/strings.xml
@@ -46,7 +46,9 @@
     <string name="menu_entry_oss_licenses">Open Source Software Lizenzen</string>
     <string name="menu_entry_view_further_oss_licenses">Weitere Open Source Software Lizenzen</string>
     <string name="menu_entry_about">Über diese App</string>
+    <string name="menu_entry_tracking">Tracking</string>
     <string name="title_activity_licenses">OSS Lizenzen</string>
+    <string name="title_activity_tracking">Tracking</string>
     <!--suppress AndroidDomInspection -->
     <string name="title_activity_main">@string/app_name</string>
     <string name="title_activity_main_demo_prefix">"DEMO "</string>
@@ -86,4 +88,12 @@
     <string name="country_spain">🇪🇸 Spanien</string>
     <string name="countries_one_europe">🇩🇪 Deutschland, 🇮🇪 Irland, 🇮🇹 Italien, 🇩🇰 Dänemark, 🇱🇻 Lettland, 🇪🇸 Spanien</string>
     <string name="point_of_exposure">Risikobegegnung</string>
+    <!-- Tracking -->
+    <string name="wrong_date_format">Das eingegebene Datum hat das falsche Format.</string>
+    <string name="endtime_before_starttime">Die Endzeit liegt vor der Startzeit.</string>
+    <string name="trackingdata">Trackingdaten</string>
+    <string name="before">vor</string>
+    <string name="minutes">Minuten</string>
+    <string name="title_enable_gps">GPS aktivieren</string>
+    <string name="info_enable_gps">Bitte aktiviere GPS, um die Tracking Funktion nutzen zu können.</string>
 </resources>

--- a/corona-warn-companion/src/main/res/values/strings.xml
+++ b/corona-warn-companion/src/main/res/values/strings.xml
@@ -46,7 +46,9 @@
     <string name="menu_entry_oss_licenses">Open Source Software Licenses</string>
     <string name="menu_entry_view_further_oss_licenses">Further Open Source Software Licenses</string>
     <string name="menu_entry_about">About this app</string>
+    <string name="menu_entry_tracking">Tracking</string>
     <string name="title_activity_licenses">OSS Licenses</string>
+    <string name="title_activity_tracking">Tracking</string>
     <!--suppress AndroidDomInspection -->
     <string name="title_activity_main">@string/app_name</string>
     <string name="title_activity_main_demo_prefix">"DEMO "</string>
@@ -116,4 +118,12 @@
     <string name="flags_one_europe" translatable="false">🇩🇪🇮🇪🇮🇹🇩🇰🇱🇻🇪🇸</string>
     <string name="toast_download_error">Error during download: %s</string>
     <string name="point_of_exposure">Point of exposure</string>
+    <!-- Tracking -->
+    <string name="wrong_date_format">The entered date has the wrong format</string>
+    <string name="endtime_before_starttime">The end time is before the start time.</string>
+    <string name="trackingdata">Tracking data</string>
+    <string name="before">before</string>
+    <string name="minutes">minutes</string>
+    <string name="title_enable_gps">Enable GPS</string>
+    <string name="info_enable_gps">Please enable GPS to use the tracking function.</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,4 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-GOOGLE_MAPS_API_KEY=AIzaSyBxd0R31aKvLBz-Jf_Tyz0pwLWPVHJoeGo
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+GOOGLE_MAPS_API_KEY=AIzaSyBxd0R31aKvLBz-Jf_Tyz0pwLWPVHJoeGo
+


### PR DESCRIPTION
I added a tracking activity. The tracking data is collected every minute (if the option is enabled) and stored in a local SQLite database. The tracking is running as a service in background. The service also starts after a reboot.

In the tracking screen you can show the tracking route on a map. Therefore you have to enter the start data and enddate. You can also enter only one date to show the position at this time. 

You need to add a Google Maps API key.