### PR TITLE
Implement a receiver for MicroG SQLite databases, without root.

### DIFF
--- a/corona-warn-companion/src/main/AndroidManifest.xml
+++ b/corona-warn-companion/src/main/AndroidManifest.xml
@@ -29,6 +29,17 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:mimeType="application/vnd.microg.exposure+sqlite3"
+                    android:host="*"
+                    android:pathPattern=".*"
+                    />
+            </intent-filter>
         </activity>
 
         <activity

--- a/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/microgreadout/MicroGDbOnDisk.java
+++ b/corona-warn-companion/src/main/java/org/tosl/coronawarncompanion/microgreadout/MicroGDbOnDisk.java
@@ -59,16 +59,25 @@ public class MicroGDbOnDisk {
         }
     }
 
-    public RpiList getRpisFromContactDB(Activity activity) {
+    public RpiList getRpisFromContactDB(Activity activity, File databaseFile) {
         RpiList rpiList = null;
 
-        copyFromGMS();
+        String databasePath = "";
+        // Only copy from gms if databaseFile is null, else directly read from there
+        if (databaseFile == null) {
+            copyFromGMS();
+            databasePath = cachePathStr + "/" + dbNameModified;
+        } else {
+            databasePath = databaseFile.getPath();
+        }
 
-        try (SQLiteDatabase microGDb = SQLiteDatabase.openDatabase(cachePathStr + "/" + dbNameModified,
+        Log.d(TAG, "Loading MicroG " + databasePath);
+
+        try (SQLiteDatabase microGDb = SQLiteDatabase.openDatabase(databasePath,
                 null, SQLiteDatabase.OPEN_READONLY)) {
 
             if (microGDb != null) {
-                Log.d(TAG, "Opened microG Database: " + gmsPathStr + "/" + dbNameModified);
+                Log.d(TAG, "Opened microG Database: " + databasePath);
 
                 Cursor cursor = microGDb.rawQuery("SELECT rpi, aem, timestamp, rssi, duration "+
                         "FROM advertisements", null);
@@ -124,6 +133,7 @@ public class MicroGDbOnDisk {
                 }
                 cursor.close();
             }
+            Log.d(TAG, "Successfully parsed MicroG database.");
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This pull request allows any other app to share a MicroG SQLite exposure database file with this app, which then automatically analyzes it. In combination with https://github.com/microg/GmsCore/pull/1291 it allows for root-less analysis of the database.

This is done by registering this app as a receiver for any `intent.action.SEND` with mime-type `application/vnd.sqlite3`. In `onCreate`, it is checked whether a database was received this way, and the mode of the app is temporarily switched to MicroG. The analysis is then done on this passed file. Since we can only access it as a file-descriptor, and SQLite expects a file, it is temporarily stored in the cache as a file.

Is there a reason you used the `singleTask` launch mode? This would complicate implementation a bit, I replaced it with `standard`. 

It might be nice to have another file-picker like solution for all app modes, but I was unsure how to best implement that. The current solution has a really nice workflow for me:
- open microg, click export, select companion app, analysis starts automatically.