### PR TITLE
Enable large heap

### DIFF
--- a/corona-warn-companion/src/main/AndroidManifest.xml
+++ b/corona-warn-companion/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:requestLegacyExternalStorage="true"
+        android:largeHeap="true"
         tools:ignore="AllowBackup">
 
         <activity


### PR DESCRIPTION
This PR enables large heap for the app's process and should hopefully mitigate the OOM-related issues reported in #133, #134 and #138 for now.

In the long run IMHO the matching algorithm could be improved by not loading all DKs into memory but matching them on the fly as they are read from storage.